### PR TITLE
Maintenance banner for website outage

### DIFF
--- a/_includes/maintenance.html
+++ b/_includes/maintenance.html
@@ -1,0 +1,5 @@
+<div class="hero-unit">
+  <p>
+    Due to a scheduled maintenance, complete power outage will occur the weekend of Oct. 4-6, 2019 . As a result, the webserver will be going down around noon Friday 10/4. The webserver will be brought back up Monday morning, Oct. 7. 
+  </p>
+</div>

--- a/index.md
+++ b/index.md
@@ -3,6 +3,7 @@ layout: default
 title: Home
 group: "navigation"
 ---
+{% include maintenance.html %}
 {% include hero.html %}
 
 PCMDI was established in 1989 at the Lawrence Livermore National Laboratory ([LLNL]), located in the [San Francisco Bay area, 


### PR DESCRIPTION
This is a banner for announcing the outage of the site for server maintenance on October 4-6, 2019.