### PR TITLE
Use h1 tags for top-level headings of ESGF CMIP6 holdings pages

### DIFF
--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/AerChemMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/AerChemMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 AerChemMIP Data Holdings
 ---
 
-## ESGF CMIP6 AerChemMIP Data Holdings
+# ESGF CMIP6 AerChemMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/C4MIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/C4MIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 C4MIP Data Holdings
 ---
 
-## ESGF CMIP6 C4MIP Data Holdings
+# ESGF CMIP6 C4MIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/CDRMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/CDRMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 CDRMIP Data Holdings
 ---
 
-## ESGF CMIP6 CDRMIP Data Holdings
+# ESGF CMIP6 CDRMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/CFMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/CFMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 CFMIP Data Holdings
 ---
 
-## ESGF CMIP6 CFMIP Data Holdings
+# ESGF CMIP6 CFMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/CMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/CMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 CMIP Data Holdings
 ---
 
-## ESGF CMIP6 CMIP Data Holdings
+# ESGF CMIP6 CMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/CORDEX/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/CORDEX/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 CORDEX Data Holdings
 ---
 
-## ESGF CMIP6 CORDEX Data Holdings
+# ESGF CMIP6 CORDEX Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/DAMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/DAMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 DAMIP Data Holdings
 ---
 
-## ESGF CMIP6 DAMIP Data Holdings
+# ESGF CMIP6 DAMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/DCPP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/DCPP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 DCPP Data Holdings
 ---
 
-## ESGF CMIP6 DCPP Data Holdings
+# ESGF CMIP6 DCPP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/DynVarMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/DynVarMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 DynVarMIP Data Holdings
 ---
 
-## ESGF CMIP6 DynVarMIP Data Holdings
+# ESGF CMIP6 DynVarMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/FAFMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/FAFMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 FAFMIP Data Holdings
 ---
 
-## ESGF CMIP6 FAFMIP Data Holdings
+# ESGF CMIP6 FAFMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/GMMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/GMMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 GMMIP Data Holdings
 ---
 
-## ESGF CMIP6 GMMIP Data Holdings
+# ESGF CMIP6 GMMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/GeoMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/GeoMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 GeoMIP Data Holdings
 ---
 
-## ESGF CMIP6 GeoMIP Data Holdings
+# ESGF CMIP6 GeoMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/HighResMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/HighResMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 HighResMIP Data Holdings
 ---
 
-## ESGF CMIP6 HighResMIP Data Holdings
+# ESGF CMIP6 HighResMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/ISMIP6/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/ISMIP6/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 ISMIP6 Data Holdings
 ---
 
-## ESGF CMIP6 ISMIP6 Data Holdings
+# ESGF CMIP6 ISMIP6 Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/LS3MIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/LS3MIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 LS3MIP Data Holdings
 ---
 
-## ESGF CMIP6 LS3MIP Data Holdings
+# ESGF CMIP6 LS3MIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/LUMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/LUMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 LUMIP Data Holdings
 ---
 
-## ESGF CMIP6 LUMIP Data Holdings
+# ESGF CMIP6 LUMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/OMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/OMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 OMIP Data Holdings
 ---
 
-## ESGF CMIP6 OMIP Data Holdings
+# ESGF CMIP6 OMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/PAMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/PAMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 PAMIP Data Holdings
 ---
 
-## ESGF CMIP6 PAMIP Data Holdings
+# ESGF CMIP6 PAMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/PMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/PMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 PMIP Data Holdings
 ---
 
-## ESGF CMIP6 PMIP Data Holdings
+# ESGF CMIP6 PMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/RFMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/RFMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 RFMIP Data Holdings
 ---
 
-## ESGF CMIP6 RFMIP Data Holdings
+# ESGF CMIP6 RFMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/SIMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/SIMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 SIMIP Data Holdings
 ---
 
-## ESGF CMIP6 SIMIP Data Holdings
+# ESGF CMIP6 SIMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/ScenarioMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/ScenarioMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 ScenarioMIP Data Holdings
 ---
 
-## ESGF CMIP6 ScenarioMIP Data Holdings
+# ESGF CMIP6 ScenarioMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/VIACSAB/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/VIACSAB/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 VIACSAB Data Holdings
 ---
 
-## ESGF CMIP6 VIACSAB Data Holdings
+# ESGF CMIP6 VIACSAB Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/VolMIP/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/VolMIP/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 VolMIP Data Holdings
 ---
 
-## ESGF CMIP6 VolMIP Data Holdings
+# ESGF CMIP6 VolMIP Data Holdings
 
 [Print-Friendly View](print_view.html)
 

--- a/CMIP6/ArchiveStatistics/esgf_data_holdings/index.md
+++ b/CMIP6/ArchiveStatistics/esgf_data_holdings/index.md
@@ -3,7 +3,7 @@ layout: default
 title: ESGF CMIP6 Data Holdings
 ---
 
-## ESGF CMIP6 Data Holdings
+# ESGF CMIP6 Data Holdings
 
 [Print-Friendly View](print_view.html)
 


### PR DESCRIPTION
The SiteImprove's accessibility review indicates that we should use h1 tags for the top-level headings of the ESGF CMIP6 holdings pages.  This is related to the changes being made in https://github.com/ESGF/esgf-utils/pull/11.