### PR TITLE
Add VDP info to footer + Google Analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ _site/
 *.swp
 .idea/
 .jekyll-cache/
+.bundle/
+vendor/bundle

--- a/Data/media/css/main.css
+++ b/Data/media/css/main.css
@@ -607,7 +607,6 @@ span.showto {
 }
 #footer-slim.footer a { 
   float:left;
-  margin-right:16px;
 }
 .subfooter {    
   font-size:10px;
@@ -616,18 +615,22 @@ span.showto {
 .subfooter span { 
   float:left; 
 }
-.subfooter a {  
-  float:left; 
+
+#footer-slim.footer .llnl {
+  margin-right:16px;
 }
 #footer-slim.footer .nnsa {
   margin-top:5px;
   margin-left:2px;
+  margin-right:16px;
 }
 #footer-slim.footer .doe {
   margin-top:0px;
+  margin-right:16px;
 }
 #footer-slim.footer .llns {
   margin-top:5px;
+  margin-right:16px;
 }
 .footernav {
     list-style: none;

--- a/Data/media/js/googleAnalyticsTag.js
+++ b/Data/media/js/googleAnalyticsTag.js
@@ -1,0 +1,29 @@
+function loadGoogleAnalytics(){
+    var ga = document.createElement('script');
+    ga.type = 'text/javascript';
+    ga.async = true;
+    ga.src = 'https://www.googletagmanager.com/gtag/js?id=UA-3843414-4';
+
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(ga, s);
+}
+
+loadGoogleAnalytics(); //Create the script
+
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+
+gtag('config', 'UA-3843414-4');
+
+/*
+https://stackoverflow.com/questions/1131079/is-it-possible-to-put-google-analytics-code-in-an-external-js-file
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-3843414-4"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-3843414-4');
+</script>
+*/

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,7 @@
         <hr />
         <div class="row">
           <div class="span12">
-            <a href="https://www.llnl.gov/" target="_blank"><img src="{{site.baseurl}}/Data/media/images/llnl.png" alt="LLNL" border="0" /></a>
+            <a class="llnl" href="https://www.llnl.gov/" target="_blank"><img src="{{site.baseurl}}/Data/media/images/llnl.png" alt="LLNL" border="0" /></a>
             <p>Lawrence Livermore National Laboratory<br />7000 East Avenue &bull; Livermore, CA 94550</p>
             <p>Operated by Lawrence Livermore National Security, LLC, for the<br />Department of Energy's National Nuclear Security Administration.</p>
             <a class="nnsa" href="https://nnsa.energy.gov/" target="_blank"><img src="{{site.baseurl}}/Data/media/images/nnsa.png" alt="NNSA" border="0" /></a>
@@ -16,7 +16,8 @@
         <br />
         <div class="row">
           <div class="span12 subfooter">
-            <span>UCRL-WEB-152471 &nbsp;|&nbsp;&nbsp;</span><a href="https://www.llnl.gov/disclaimer" target="_blank">Privacy &amp; Legal Notice</a>
+            <span>UCRL-WEB-152471 &nbsp;|&nbsp;&nbsp;</span><span><a href="https://www.llnl.gov/disclaimer" target="_blank">Privacy &amp; Legal Notice</a> &nbsp;&nbsp;|&nbsp;&nbsp;</span>
+            <span>Learn about the Department of Energy’s &nbsp;</span><a href="https://doe.responsibledisclosure.com/hc/en-us">Vulnerability Disclosure Program</a>
           </div>
         </div>
       </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,3 +16,6 @@
 
 <!-- LLNL Analytics -->
 <script src="{{site.baseurl}}/Data/media/js/matomo.js"></script>
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script type="text/javascript" src="{{site.baseurl}}/Data/media/js/googleAnalyticsTag.js" ></script>


### PR DESCRIPTION
Resolves #429 
Resolves #431 

@durack1 This PR will add your Google Analytics script to all pages on pcmdi.llnl.gov.

Footer now contains link to the Vulnerability Disclosure Program site.

![Screenshot 2022-02-11 at 17-44-21 Staff](https://user-images.githubusercontent.com/42009431/153691643-42b0d232-d62c-483e-a906-cbc6c5f3b9af.png)

