### PR TITLE
Patch 4

### DIFF
--- a/staff/index.md
+++ b/staff/index.md
@@ -17,7 +17,7 @@ Name | Position | E-mail | Phone Number
 [Gleckler, Peter][gleckler] | Research Scientist | gleckler1@llnl.gov | (925) 422-7631
 [Lee, Jiwoo][lee] | Research Scientist | lee1043@llnl.gov | (925) 422-0932
 [Ma, Hsi-Yen][ma] | Research Scientist | ma21@llnl.gov | (925) 422-5958
-[Mauzey, Christopher][mauzey] | Computer Scientist | mauzey1@llnl.gov | (925) 424-4644
+[Mauzey, Christopher][mauzey] | Computer Scientist | mauzey1@llnl.gov | (925) 422-6970
 [Pallotta, Giuliana][pallotta] | Research Scientist | pallottagold1@llnl.gov | (925) 422-2778
 [Po-Chedley, Stephen][pochedley] | Research Scientist | pochedley1@llnl.gov | (925) 422-3421
 [Taylor, Karl][taylor] | Research Scientist | taylor13@llnl.gov | (925) 423-3623
@@ -25,11 +25,15 @@ Name | Position | E-mail | Phone Number
 {: class="table table-striped"}
 
 ## Funded collaborators
+
+--- | --- | --- | --- | ---
 [Hoang, Anthony][hoang] | Systems Manager | hoang1@llnl.gov | (925) 423-6733
 [Jefferson, Angela][jefferson] | Program Administrator | jefferson9@llnl.gov | (925) 422-5932
 {: class="table table-striped"}
 
 ## Project collaborators
+
+--- | --- | --- | --- | ---
 [Caldwell, Peter][caldwell] | Research Scientist | caldwell19@llnl.gov | (925) 422-4197
 [Covey, Curt][covey] | Research Scientist | covey1@llnl.gov | (925) 422-1828
 [Doutriaux, Charles][doutriaux] | Computer Scientist | doutriaux1@llnl.gov | (925) 422-1487
@@ -42,6 +46,8 @@ Name | Position | E-mail | Phone Number
 {: class="table table-striped"}
 
 ## Former participants
+
+--- | --- | --- | --- | ---
 [Harris, Matthew][harris] | Computer Scientist | harris112@llnl.gov | (925) 423-8978
 [Sperber, Ken][sperber] | Research Scientist | |
 {: class="table table-striped"}
@@ -59,12 +65,13 @@ Name | Position | E-mail | Phone Number
 [hoang]: {{site.baseurl}}/staff/hoang
 [klein]: https://people.llnl.gov/klein21
 [lee]: {{site.baseurl}}/staff/lee
-[ma]:
-[mauzey]:
+[ma]: https://people.llnl.gov/ma21
+[mauzey]: https://people.llnl.gov/mauzey1
 [nadeau]: {{site.baseurl}}/staff/nadeau
 [painter]: {{site.baseurl}}/staff/painter
+[pallotta]: https://people.llnl.gov/pallottagold1
 [phillips]: {{site.baseurl}}/staff/phillips
-[pochedley]:
+[pochedley]: https://people.llnl.gov/pochedley1
 [santer]: {{site.baseurl}}/staff/santer
 [sperber]: {{site.baseurl}}/staff/sperber
 [taylor]: {{site.baseurl}}/staff/taylor

--- a/staff/index.md
+++ b/staff/index.md
@@ -45,39 +45,47 @@ Name | Position | E-mail | Phone Number
 [Ullrich, Paul][ullrich] | | |
 [Han, Yushan][hany] | | |
 [Chen, Hongyu][chenh] | | |
+
+  | | |
+[Ma, Po-Lun][mapnnl] | | |
 {: class="table table-striped"}
 
 ## Affiliated contributors
 
 --- | --- | --- | --- | ---
+[Bader, David][bader] | | |
 [Caldwell, Peter][caldwell] | Research Scientist | caldwell19@llnl.gov | (925) 422-4197
 [Covey, Curt][covey] | Research Scientist | covey1@llnl.gov | (925) 422-1828
-[Doutriaux, Charles][doutriaux] | Computer Scientist | doutriaux1@llnl.gov | (925) 422-1487
+[Golaz, Chris][golaz] | Research Scientist | golaz1@llnl.gov | (925) 423-6912
 [Nadeau, Denis][nadeau] | Computer Scientist | |
 [Painter, Jeff][painter] | Computer Scientist | |
-[Phillips, Tom][phillips] | Research Scientist | phillips14@llnl.gov | (925) 422-0072
 [Santer, Ben][santer] | Research Scientist | |
-[Williams, Dean][williams] | Computer Scientist	 | |
 [Xie, Shaocheng][xie] | Research Scientist | xie2@llnl.gov | (925) 422-6023
+[Zhang, Chengzhu][zhangc] | Research Scientist | zhang40@llnl.gov | (925) 424-4573
 {: class="table table-striped"}
 
 ## Former participants
 
 --- | --- | --- | --- | ---
 [Chen, Di][chen] | | |
+[Doutriaux, Charles][doutriaux] | Computer Scientist | doutriaux1@llnl.gov | (925) 422-1487
 [Harris, Matthew][harris] | Computer Scientist | harris112@llnl.gov | (925) 423-8978
+[Phillips, Tom][phillips] | Research Scientist | phillips14@llnl.gov | (925) 422-0072
 [Sperber, Ken][sperber] | Research Scientist | |
+[Williams, Dean][williams] | Computer Scientist	 | |
 {: class="table table-striped"}
 
 ###### Document version: 7 March 2022
 
 [ahn]: https://people.llnl.gov/ahn6
 [ames]: {{site.baseurl}}/staff/ames
+[bader]: https://people.llnl.gov/bader2
 [bonfils]: {{site.baseurl}}/staff/bonfils
 [caldwell]: {{site.baseurl}}/staff/caldwell
 [covey]: {{site.baseurl}}/staff/covey
 [doutriaux]: {{site.baseurl}}/staff/doutriaux
 [durack]: {{site.baseurl}}/staff/durack
+[golaz]: https://people.llnl.gov/golaz1
 [gleckler]: {{site.baseurl}}/staff/gleckler
 [harris]: {{site.baseurl}}/staff/harris
 [hoang]: {{site.baseurl}}/staff/hoang
@@ -100,6 +108,7 @@ Name | Position | E-mail | Phone Number
 [jefferson]: {{site.baseurl}}/staff/jefferson
 [xie]: {{site.baseurl}}/staff/Xie
 [zelinka]: https://markdzelinka.wordpress.com/
+[zhang40]: https://people.llnl.gov/zhang40
 
 [hall]: https://dept.atmos.ucla.edu/alexhall/people/alex-hall
 [norris]: https://dept.atmos.ucla.edu/alexhall/people/jesse-norris
@@ -114,3 +123,5 @@ Name | Position | E-mail | Phone Number
 [ullrich]: https://climate.ucdavis.edu/people.php
 [chenh]: https://climate.ucdavis.edu/people.php
 [hany]: https://climate.ucdavis.edu/people.php
+
+[mapnnl]: https://www.pnnl.gov/science/staff/staff_info.asp?staff_num=7579

--- a/staff/index.md
+++ b/staff/index.md
@@ -54,6 +54,13 @@ UC Davis |  |  |
 [Chen, Hongyu][chenh] | | |
 {: class="table table-striped"}
 
+Princeton University/NOAA-GFDL |  |  |
+--- | --- | --- | ---
+[Tesdal, Jan-Erik][tesdal] | | |
+[Griffies, Stephen][griffies] | | |
+[Krasting, John][krasting] | | |
+{: class="table table-striped"}
+
 Pacific Northwest National Laboratory |  |  |
 --- | --- | --- | ---
 [Ma, Po-Lun][mapnnl] | | |
@@ -130,5 +137,9 @@ Pacific Northwest National Laboratory |  |  |
 [ullrich]: https://climate.ucdavis.edu/people.php
 [chenh]: https://climate.ucdavis.edu/people.php
 [hany]: https://climate.ucdavis.edu/people.php
+
+[tesdal]: https://aos.princeton.edu/people/jan-erik-tesdal
+[griffies]: https://www.gfdl.noaa.gov/stephen-griffies-homepage/
+[krasting]: https://www.gfdl.noaa.gov/john-krasting-homepage/
 
 [mapnnl]: https://www.pnnl.gov/science/staff/staff_info.asp?staff_num=7579

--- a/staff/index.md
+++ b/staff/index.md
@@ -4,7 +4,7 @@ title:  Staff
 group: "navigation"
 ---
 
-# Participant directory
+# The PCMDI Community
 
 ## Project staff at LLNL
 
@@ -17,7 +17,7 @@ Name | Position | E-mail | Phone Number
 [Durack, Paul][durack] | Research Scientist | durack1@llnl.gov | (925) 422-5208
 [Gleckler, Peter][gleckler] | Research Scientist | gleckler1@llnl.gov | (925) 422-7631
 [Hoang, Anthony][hoang] | Systems Manager | hoang1@llnl.gov | (925) 423-6733
-[Jefferson, Angela][jefferson] | Program Administrator | jefferson9@llnl.gov | (925) 422-5932
+[Jefferson, Angela][jefferson] | Project Administrator | jefferson9@llnl.gov | (925) 422-5932
 [Lee, Jiwoo][lee] | Research Scientist | lee1043@llnl.gov | (925) 422-0932
 [Ma, Hsi-Yen][ma] | Research Scientist | ma21@llnl.gov | (925) 422-5958
 [Mauzey, Christopher][mauzey] | Computer Scientist | mauzey1@llnl.gov | (925) 422-6970
@@ -33,8 +33,18 @@ Name | Position | E-mail | Phone Number
 ## Collaborators @ other institutions
 
 --- | --- | --- | --- | ---
-[Hoang, Anthony][hoang] | Systems Manager | hoang1@llnl.gov | (925) 423-6733
-[Jefferson, Angela][jefferson] | Program Administrator | jefferson9@llnl.gov | (925) 422-5932
+[Hall, Alex][hall] | | |
+[Norris, Jesse][norris] | | |
+[Thackeray, Chad][thackeray] | | |
+[Madakumbura, Gavin][madakumbura] | | |
+  | | |
+[Barnes, Elizabeth][barnes] | | |
+[Arcodia, Marybeth][arcodia] | | |
+[Valkonen, Elina][valkonen] | | |
+  | | |
+[Ullrich, Paul][ullrich] | | |
+[Han, Yushan][hany] | | |
+[Chen, Hongyu][chenh] | | |
 {: class="table table-striped"}
 
 ## Affiliated contributors
@@ -54,12 +64,12 @@ Name | Position | E-mail | Phone Number
 ## Former participants
 
 --- | --- | --- | --- | ---
+[Chen, Di][chen] | | |
 [Harris, Matthew][harris] | Computer Scientist | harris112@llnl.gov | (925) 423-8978
 [Sperber, Ken][sperber] | Research Scientist | |
 {: class="table table-striped"}
 
 ###### Document version: 7 March 2022
-
 
 [ahn]: https://people.llnl.gov/ahn6
 [ames]: {{site.baseurl}}/staff/ames
@@ -90,3 +100,17 @@ Name | Position | E-mail | Phone Number
 [jefferson]: {{site.baseurl}}/staff/jefferson
 [xie]: {{site.baseurl}}/staff/Xie
 [zelinka]: https://markdzelinka.wordpress.com/
+
+[hall]: https://dept.atmos.ucla.edu/alexhall/people/alex-hall
+[norris]: https://dept.atmos.ucla.edu/alexhall/people/jesse-norris
+[thackeray]: https://dept.atmos.ucla.edu/alexhall/people/chad-thackeray
+[madakumbura]: https://dept.atmos.ucla.edu/alexhall/people/gavin-dayanga
+[chend]: https://dept.atmos.ucla.edu/alexhall/people/di-chen
+
+[barnes]: https://www.atmos.colostate.edu/people/faculty/barnes/
+[arcodia]: https://sites.google.com/view/barnesgroup-csu/group
+[valkonen]: https://sites.google.com/view/barnesgroup-csu/group
+
+[ullrich]: https://climate.ucdavis.edu/people.php
+[chenh]: https://climate.ucdavis.edu/people.php
+[hany]: https://climate.ucdavis.edu/people.php

--- a/staff/index.md
+++ b/staff/index.md
@@ -10,8 +10,8 @@ group: "navigation"
 
 Name | Position | E-mail | Phone Number
 --- | --- | --- | --- | ---
-[Klein, Steve][klein] | Projector Leader | klein21@llnl.gov |
-[Ahn, Min-Seop][ames] | Post-Doctoral Research Scientist | ahn6@llnl.gov | (925) 423-2121
+[Klein, Steve][klein] | Project Leader | klein21@llnl.gov |
+[Ahn, Min-Seop][ahn] | Post-Doctoral Research Scientist | ahn6@llnl.gov | (925) 423-2121
 [Ames, Sasha][ames] | Computer Scientist | ames4@llnl.gov | (925) 424-4644
 [Bonfils, Celine][bonfils] | Research Scientist | bonfils2@llnl.gov | (925) 423-9923
 [Durack, Paul][durack] | Research Scientist | durack1@llnl.gov | (925) 422-5208
@@ -61,7 +61,7 @@ Name | Position | E-mail | Phone Number
 ###### Document version: 7 March 2022
 
 
-[ahn]: {{site.baseurl}}/staff/ahn6
+[ahn]: https://people.llnl.gov/ahn6
 [ames]: {{site.baseurl}}/staff/ames
 [bonfils]: {{site.baseurl}}/staff/bonfils
 [caldwell]: {{site.baseurl}}/staff/caldwell
@@ -72,7 +72,7 @@ Name | Position | E-mail | Phone Number
 [harris]: {{site.baseurl}}/staff/harris
 [hoang]: {{site.baseurl}}/staff/hoang
 [klein]: https://people.llnl.gov/klein21
-[lee]: {{site.baseurl}}/staff/lee1043
+[lee]: {{site.baseurl}}/staff/lee
 [ma]: https://people.llnl.gov/ma21
 [mauzey]: https://people.llnl.gov/mauzey1
 [ordonez]: https://people.llnl.gov/ordonez4

--- a/staff/index.md
+++ b/staff/index.md
@@ -4,47 +4,71 @@ title:  Staff
 group: "navigation"
 ---
 
-# Staff Directory
+# Participant directory
+
+## Project staff
 
 Name | Position | E-mail | Phone Number
 --- | --- | --- | --- | ---
-[Taylor, Karl][taylor] | Program Director |	taylor13@llnl.gov |	(925) 423-3623
-[Ames, Sasha][ames] | Computer Scientist | ames4@llnl.gov	| (925) 424-4644
+[Klein, Steve][klein] | Program Director | klein21@llnl.gov |
+[Ames, Sasha][ames] | Computer Scientist | ames4@llnl.gov | (925) 424-4644
 [Bonfils, Celine][bonfils] | Research Scientist | bonfils2@llnl.gov | (925) 423-9923
-[Caldwell, Peter][caldwell] | Research Scientist | caldwell19@llnl.gov | (925) 422-4197
-[Covey, Curt][covey] | Research Scientist | covey1@llnl.gov	| (925) 422-1828
-[Doutriaux, Charles][doutriaux] | Computer Scientist	| doutriaux1@llnl.gov	| (925) 422-1487
-[Durack, Paul][durack] | Research Scientist	| durack1@llnl.gov	| (925) 422-5208
-[Gleckler, Peter][gleckler] | Research Scientist | gleckler1@llnl.gov	| (925) 422-7631
-[Harris, Matthew][harris] | Computer Scientist | harris112@llnl.gov	| (925) 423-8978
-[Hoang, Anthony][hoang] | Systems Manager	| hoang1@llnl.gov	| (925) 423-6733
-[Jefferson, Angela][jefferson] | Program Administrator | jefferson9@llnl.gov | (925) 422-5932
+[Durack, Paul][durack] | Research Scientist | durack1@llnl.gov | (925) 422-5208
+[Gleckler, Peter][gleckler] | Research Scientist | gleckler1@llnl.gov | (925) 422-7631
 [Lee, Jiwoo][lee] | Research Scientist | lee1043@llnl.gov | (925) 422-0932
-[Nadeau, Denis][nadeau] | Computer Scientist | nadeau1@llnl.gov | (925) 423-3123
-[Painter, Jeff][painter] | Computer Scientist	| painter1@llnl.gov	| (925) 422-8114
-[Phillips, Tom][phillips] | Research Scientist | phillips14@llnl.gov | (925) 422-0072
-[Santer, Ben][santer] | Research Scientist | santer1@llnl.gov	|
-[Sperber, Ken][sperber] | Research Scientist | sperber1@llnl.gov | (925) 422-7720
-[Williams, Dean][williams] | Computer Scientist	| williams13@llnl.gov	| (925) 423-0145
-[Xie, Shaocheng][xie] | Research Scientist	| xie2@llnl.gov	| (925) 422-6023
+[Ma, Hsi-Yen][ma] | Research Scientist | ma21@llnl.gov | (925) 422-5958
+[Mauzey, Christopher][mauzey] | Computer Scientist | mauzey1@llnl.gov | (925) 424-4644
+[Pallotta, Giuliana][pallotta] | Research Scientist | pallottagold1@llnl.gov | (925) 422-2778
+[Po-Chedley, Stephen][pochedley] | Research Scientist | pochedley1@llnl.gov | (925) 422-3421
+[Taylor, Karl][taylor] | Research Scientist | taylor13@llnl.gov | (925) 423-3623
+[Zelinka, Mark][zelinka] | Research Scientist | zelinka1@llnl.gov | (925) 423-5146
 {: class="table table-striped"}
 
-[taylor]: {{site.baseurl}}/staff/taylor/index.html
-[ames]: {{site.baseurl}}/staff/ames/index.html
-[bonfils]: {{site.baseurl}}/staff/bonfils/index.html
-[caldwell]: {{site.baseurl}}/staff/caldwell/index.html
-[covey]: {{site.baseurl}}/staff/covey/index.html
-[doutriaux]: {{site.baseurl}}/staff/doutriaux/index.html
-[durack]: {{site.baseurl}}/staff/durack/index.html
-[gleckler]: {{site.baseurl}}/staff/gleckler/index.html
-[harris]: {{site.baseurl}}/staff/harris/index.html
-[hoang]: {{site.baseurl}}/staff/hoang/index.html
-[lee]: {{site.baseurl}}/staff/lee/index.html
-[nadeau]: {{site.baseurl}}/staff/nadeau/index.html
-[painter]: {{site.baseurl}}/staff/painter/index.html
-[phillips]: {{site.baseurl}}/staff/phillips/index.html
-[santer]: {{site.baseurl}}/staff/santer/index.html
-[sperber]: {{site.baseurl}}/staff/sperber/index.html
-[williams]:{{site.baseurl}}/staff/williams/index.html
-[jefferson]: {{site.baseurl}}/staff/jefferson/index.html
-[xie]: {{site.baseurl}}/staff/Xie/index.html
+## Funded collaborators
+[Hoang, Anthony][hoang] | Systems Manager | hoang1@llnl.gov | (925) 423-6733
+[Jefferson, Angela][jefferson] | Program Administrator | jefferson9@llnl.gov | (925) 422-5932
+{: class="table table-striped"}
+
+## Project collaborators
+[Caldwell, Peter][caldwell] | Research Scientist | caldwell19@llnl.gov | (925) 422-4197
+[Covey, Curt][covey] | Research Scientist | covey1@llnl.gov | (925) 422-1828
+[Doutriaux, Charles][doutriaux] | Computer Scientist | doutriaux1@llnl.gov | (925) 422-1487
+[Nadeau, Denis][nadeau] | Computer Scientist | |
+[Painter, Jeff][painter] | Computer Scientist | |
+[Phillips, Tom][phillips] | Research Scientist | phillips14@llnl.gov | (925) 422-0072
+[Santer, Ben][santer] | Research Scientist | |
+[Williams, Dean][williams] | Computer Scientist	 | |
+[Xie, Shaocheng][xie] | Research Scientist | xie2@llnl.gov | (925) 422-6023
+{: class="table table-striped"}
+
+## Former participants
+[Harris, Matthew][harris] | Computer Scientist | harris112@llnl.gov | (925) 423-8978
+[Sperber, Ken][sperber] | Research Scientist | |
+{: class="table table-striped"}
+
+###### Document version: 3 March 2022
+
+[ames]: {{site.baseurl}}/staff/ames
+[bonfils]: {{site.baseurl}}/staff/bonfils
+[caldwell]: {{site.baseurl}}/staff/caldwell
+[covey]: {{site.baseurl}}/staff/covey
+[doutriaux]: {{site.baseurl}}/staff/doutriaux
+[durack]: {{site.baseurl}}/staff/durack
+[gleckler]: {{site.baseurl}}/staff/gleckler
+[harris]: {{site.baseurl}}/staff/harris
+[hoang]: {{site.baseurl}}/staff/hoang
+[klein]: https://people.llnl.gov/klein21
+[lee]: {{site.baseurl}}/staff/lee
+[ma]:
+[mauzey]:
+[nadeau]: {{site.baseurl}}/staff/nadeau
+[painter]: {{site.baseurl}}/staff/painter
+[phillips]: {{site.baseurl}}/staff/phillips
+[pochedley]:
+[santer]: {{site.baseurl}}/staff/santer
+[sperber]: {{site.baseurl}}/staff/sperber
+[taylor]: {{site.baseurl}}/staff/taylor
+[williams]:{{site.baseurl}}/staff/williams
+[jefferson]: {{site.baseurl}}/staff/jefferson
+[xie]: {{site.baseurl}}/staff/Xie
+[zelinka]: https://markdzelinka.wordpress.com/

--- a/staff/index.md
+++ b/staff/index.md
@@ -6,32 +6,38 @@ group: "navigation"
 
 # Participant directory
 
-## Project staff
+## Project staff at LLNL
 
 Name | Position | E-mail | Phone Number
 --- | --- | --- | --- | ---
-[Klein, Steve][klein] | Program Director | klein21@llnl.gov |
+[Klein, Steve][klein] | Projector Leader | klein21@llnl.gov |
+[Ahn, Min-Seop][ames] | Post-Doctoral Research Scientist | ahn6@llnl.gov | (925) 423-2121
 [Ames, Sasha][ames] | Computer Scientist | ames4@llnl.gov | (925) 424-4644
 [Bonfils, Celine][bonfils] | Research Scientist | bonfils2@llnl.gov | (925) 423-9923
 [Durack, Paul][durack] | Research Scientist | durack1@llnl.gov | (925) 422-5208
 [Gleckler, Peter][gleckler] | Research Scientist | gleckler1@llnl.gov | (925) 422-7631
+[Hoang, Anthony][hoang] | Systems Manager | hoang1@llnl.gov | (925) 423-6733
+[Jefferson, Angela][jefferson] | Program Administrator | jefferson9@llnl.gov | (925) 422-5932
 [Lee, Jiwoo][lee] | Research Scientist | lee1043@llnl.gov | (925) 422-0932
 [Ma, Hsi-Yen][ma] | Research Scientist | ma21@llnl.gov | (925) 422-5958
 [Mauzey, Christopher][mauzey] | Computer Scientist | mauzey1@llnl.gov | (925) 422-6970
+[Ordonez, Ana][ordonez] | Research Scientist | ordonez4@llnl.gov | 
 [Pallotta, Giuliana][pallotta] | Research Scientist | pallottagold1@llnl.gov | (925) 422-2778
 [Po-Chedley, Stephen][pochedley] | Research Scientist | pochedley1@llnl.gov | (925) 422-3421
+[Qin, Hongchen][qin5] | Post-Doctoral Research Scientist | qin5@llnl.gov | (925) 424-3922
+[Qin, Yi][qin4] | Post-Doctoral Research Scientist | qin4@llnl.gov | (925) 423-7007
 [Taylor, Karl][taylor] | Research Scientist | taylor13@llnl.gov | (925) 423-3623
 [Zelinka, Mark][zelinka] | Research Scientist | zelinka1@llnl.gov | (925) 423-5146
 {: class="table table-striped"}
 
-## Funded collaborators
+## Collaborators @ other institutions
 
 --- | --- | --- | --- | ---
 [Hoang, Anthony][hoang] | Systems Manager | hoang1@llnl.gov | (925) 423-6733
 [Jefferson, Angela][jefferson] | Program Administrator | jefferson9@llnl.gov | (925) 422-5932
 {: class="table table-striped"}
 
-## Project collaborators
+## Affiliated contributors
 
 --- | --- | --- | --- | ---
 [Caldwell, Peter][caldwell] | Research Scientist | caldwell19@llnl.gov | (925) 422-4197
@@ -52,8 +58,10 @@ Name | Position | E-mail | Phone Number
 [Sperber, Ken][sperber] | Research Scientist | |
 {: class="table table-striped"}
 
-###### Document version: 3 March 2022
+###### Document version: 7 March 2022
 
+
+[ahn]: {{site.baseurl}}/staff/ahn6
 [ames]: {{site.baseurl}}/staff/ames
 [bonfils]: {{site.baseurl}}/staff/bonfils
 [caldwell]: {{site.baseurl}}/staff/caldwell
@@ -64,14 +72,17 @@ Name | Position | E-mail | Phone Number
 [harris]: {{site.baseurl}}/staff/harris
 [hoang]: {{site.baseurl}}/staff/hoang
 [klein]: https://people.llnl.gov/klein21
-[lee]: {{site.baseurl}}/staff/lee
+[lee]: {{site.baseurl}}/staff/lee1043
 [ma]: https://people.llnl.gov/ma21
 [mauzey]: https://people.llnl.gov/mauzey1
+[ordonez]: https://people.llnl.gov/ordonez4
 [nadeau]: {{site.baseurl}}/staff/nadeau
 [painter]: {{site.baseurl}}/staff/painter
 [pallotta]: https://people.llnl.gov/pallottagold1
 [phillips]: {{site.baseurl}}/staff/phillips
 [pochedley]: https://people.llnl.gov/pochedley1
+[qin5]: https://people.llnl.gov/qin5
+[qin4]: https://people.llnl.gov/qin4
 [santer]: {{site.baseurl}}/staff/santer
 [sperber]: {{site.baseurl}}/staff/sperber
 [taylor]: {{site.baseurl}}/staff/taylor


### PR DESCRIPTION
@mauzey1 
@durack1 

Here's a set of changes to the PCMDI Staff File that represent a reasonable baseline and could be published.

There are few issues:

Under "Collaborators @ other institutions", I tried to insert a blank line between groups of people at different institutions. I don't know if this worked.
Some names could be in different categories (especially Affiliated Contributors vs. Former Participants) and it is arbitrary how recent you need to be call a "former participant"