### PR TITLE
Enable forked repository generating same-looking website for testing purpose

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-lee1043.pcmdi_website_test.io

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-pcmdi_website_test.io

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+pcmdi_website_test.io

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-pcmdi_website_test.io
+lee1043.pcmdi_website_test.io

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,3 @@
-name: PCMDI
-author: webshootertk
+title: PCMDI
+author: PCMDI
 markdown: kramdown
-
-baseurl: ""


### PR DESCRIPTION
When jekyll generate website from the forked directory, links to css and others are messed up because `{{site.baseurl}}` did not capture the whole address. 

For example, when 
- website from the original repo is `abc.github.io`,
- and website from the forked repo is `USER.github.io/abc.github.io`

In forked repo, `{{site.baseurl}}` captures `USER.github.io` when generating the website, thus it does look broken with links are also broken. 

This change will allow forked repo to generate a twin PCMDI website for testing purpose before pushing changes to the original repo. 

I referred the [same file for the CMEC website](https://github.com/PCMDI/CMEC/blob/master/_config.yml) for this change. 

@mauzey1 could you share your knowledge to check if I changed in a correct way?