### PR TITLE
Add a shortcut for the metrics page to shorten the web address

### DIFF
--- a/metrics
+++ b/metrics
@@ -1,0 +1,1 @@
+research/metrics/


### PR DESCRIPTION
A symlink added to have "https://pcmdi.llnl.gov/metrics" to point to "https://pcmdi.llnl.gov/research/metrics"