### PR TITLE
Replace pcmdi.github.io/cmor-site links with cmor.llnl.gov links

### DIFF
--- a/ipcc/IPCC_output_requirements.htm
+++ b/ipcc/IPCC_output_requirements.htm
@@ -212,7 +212,7 @@ other projects. </p>
 href="#_ftn1" name="_ftnref1" title=""><span class=MsoFootnoteReference><span style='font-size:12.0pt;font-family:"Times New Roman"'>[1]</span></span></a>
 (pronounced &quot;see more&quot;) has been written to output data that conforms
 to these requirements. <a
-href="{{site.baseurl}}/software/cmor/cmor_users_guide.pdf">Documentation</a><a
+href="../software/cmor/cmor_users_guide.pdf">Documentation</a><a
 href="#_ftn2" name="_ftnref2" title=""><span class=MsoFootnoteReference><span
 class=MsoFootnoteReference><span style='font-size:12.0pt;font-family:"Times New Roman"'>[2]</span></span></span></a>
 for this code explains how it can substantially reduce the burden placed on the
@@ -3101,7 +3101,7 @@ font-family:"Courier New"'>&nbsp;</span></p>
 <p class=MsoFootnoteText><a href="#_ftnref1" name="_ftn1" title=""><span
 class=MsoFootnoteReference><span class=MsoFootnoteReference><span
 style='font-size:10.0pt;font-family:"Times New Roman"'>[1]</span></span></span></a>
-See <a href="https://pcmdi.github.io/cmor-site/">https://pcmdi.github.io/cmor-site/</a></p>
+See <a href="https://cmor.llnl.gov/archive/cmor1/">https://cmor.llnl.gov/archive/cmor1/</a></p>
 
 </div>
 
@@ -3110,7 +3110,7 @@ See <a href="https://pcmdi.github.io/cmor-site/">https://pcmdi.github.io/cmor-si
 <p class=MsoFootnoteText><a href="#_ftnref2" name="_ftn2" title=""><span
 class=MsoFootnoteReference><span class=MsoFootnoteReference><span
 style='font-size:10.0pt;font-family:"Times New Roman"'>[2]</span></span></span></a>
-See <a href="{{site.baseurl}}/software/cmor/cmor_users_guide.pdf"> cmor_users_guide.pdf</a></p>
+See <a href="../software/cmor/cmor_users_guide.pdf"> cmor_users_guide.pdf</a></p>
 
 </div>
 

--- a/ipcc/about_ipcc.html
+++ b/ipcc/about_ipcc.html
@@ -105,7 +105,7 @@ historical details</a></p>
                                 <li>
                                 <a href="{{site.baseurl}}/software/cmor/cmor_users_guide.pdf">CMOR software</a> for producing output 
                                 conforming to IPCC requirements is available
-                                <a href="https://pcmdi.github.io/cmor-site/">here</a>.</li>
+                                <a href="https://cmor.llnl.gov/archive/cmor1/">here</a>.</li>
                                 </ul>
                           </li>
                                 <li>

--- a/ipcc/about_ipcc_12_07.html
+++ b/ipcc/about_ipcc_12_07.html
@@ -98,7 +98,7 @@ historical details</a></p>
                                 <li>
                                 <a href="{{site.baseurl}}/software/cmor/cmor_users_guide.pdf">CMOR software</a> for producing output 
                                 conforming to IPCC requirements is available
-                                <a href="https://pcmdi.github.io/cmor-site/">here</a>.</li>
+                                <a href="https://cmor.llnl.gov/archive/cmor1/">here</a>.</li>
                                 </ul>
                           </li>
                                 <li>

--- a/ipcc/about_ipcc_7_25_06.html
+++ b/ipcc/about_ipcc_7_25_06.html
@@ -64,7 +64,7 @@ title: PCMDI - IPCC
                                 <a href="../software/cmor/cmor_users_guide.pdf">
                                 CMOR software</a> for producing output 
                                 conforming to IPCC requirements is available
-                                <a href="https://pcmdi.github.io/cmor-site/">here</a>.</li>
+                                <a href="https://cmor.llnl.gov/archive/cmor1/">here</a>.</li>
                                 </ul>
                           </li>
                                 <li><a href="info_for_modeling_groups.php">Additional important  requests and information</a></li>

--- a/ipcc/standard_output13.htm
+++ b/ipcc/standard_output13.htm
@@ -200,16 +200,16 @@ contain all variables for a single time step. </p>
 <p>
 To facilitate adherence to these standards, the PCMDI has written (in FORTRAN 90) a standard output code 
 called CMOR (pronounced "see more"; see
-<a href="https://pcmdi.github.io/cmor-site/">https://pcmdi.github.io/cmor-site/</a>), which is now available as open source.
+<a href="https://cmor.llnl.gov/archive/cmor1/">https://cmor.llnl.gov/archive/cmor1/</a>), which is now available as open source.
 This code structures the data uniformly and writes netCDF files in full compliance with IPCC requirements.
 Use of CMOR is being encouraged (and in some cases required) by various ongoing model intercomparison 
 projects. <span style="font-size: 12.0pt; font-family: Times New Roman">The CMOR 
 documentation in pdf format is available at
-<a href="{{site.baseurl}}/software/cmor/cmor_users_guide.pdf" style="color: blue; text-decoration: underline; text-underline: single">
+<a href="../software/cmor/cmor_users_guide.pdf" style="color: blue; text-decoration: underline; text-underline: single">
 here</a>, and the source
 code is available at&nbsp;
-<a href="https://pcmdi.github.io/cmor-site//download" style="color: blue; text-decoration: underline; text-underline: single">
-https://pcmdi.github.io/cmor-site//download</a>. </span>For further information, contact
+<a href="https://cmor.llnl.gov/archive/cmor1/" style="color: blue; text-decoration: underline; text-underline: single">
+https://cmor.llnl.gov/archive/cmor1/</a>. </span>For further information, contact
 <a href="mailto:taylor13@llnl.gov"> taylor13@llnl.gov.</a></p>
 <p>The notes that appear in the following tables are meant to provide precise 
 definitions of the requested fields.&nbsp; Sometimes it may be impossible to 

--- a/ipcc/standard_output14.html
+++ b/ipcc/standard_output14.html
@@ -322,7 +322,7 @@ This code structures the data uniformly and writes netCDF files in full complian
 with IPCC requirements. Use of CMOR is being encouraged (and in some cases
 required) by various ongoing model intercomparison projects.� The CMOR
 documentation in pdf format is available <a
-href="{{site.baseurl}}/software/cmor/cmor_users_guide.pdf">here</a>,
+href="../software/cmor/cmor_users_guide.pdf">here</a>,
 and the source code is available <a
 href="https://github.com/PCMDI/cmor">on Github</a>.
 For further information, contact <a href="mailto:taylor13@llnl.gov">taylor13@llnl.gov.</a></p>

--- a/mips/amip/AMIP2EXPDSN/BCS/amipbc_dwnld.html
+++ b/mips/amip/AMIP2EXPDSN/BCS/amipbc_dwnld.html
@@ -101,14 +101,14 @@ menuSoftware[0]='<table width="100%" border="0" cellpadding="3" cellspacing="1" 
 //menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/download/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/download/" class="popupMenu">Downloads</a></td></tr>'
 //menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/support/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/support/" class="popupMenu">Support</a></td></tr>'
 //menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/" class="popupMenu">UV-CDAT</a></td></tr>'
-//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://pcmdi.github.io/cmor-site//\');return document.MM_returnValue"><a href="https://pcmdi.github.io/cmor-site//" class="popupMenu">CMOR</a></td></tr>'
+//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov//\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu">CMOR</a></td></tr>'
 
 menuSoftware[1]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://aims.llnl.gov/\');return document.MM_returnValue"><a href="http://aims.llnl.gov/" class="popupMenu" target="_blank">AIMS</a></td></tr>'
 menuSoftware[2]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://esgf.llnl.gov/\');return document.MM_returnValue"><a href="http://esgf.llnl.gov/" class="popupMenu" target="_blank">ESGF</a></td></tr>'
 menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi9.llnl.gov/esgf-web-fe/\');return document.MM_returnValue"><a href="http://pcmdi9.llnl.gov/esgf-web-fe/" class="popupMenu" target="_blank">ESGF Node</a></td></tr>'
 menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uvcdat.llnl.gov/\');return document.MM_returnValue"><a href="http://uvcdat.llnl.gov/" class="popupMenu" target="_blank">UV-CDAT</a></td></tr>'
 menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uv-cdat.github.io/cdat-site/\');return document.MM_returnValue"><a href="http://uv-cdat.github.io/cdat-site/" class="popupMenu" target="_blank">Old CDAT Tutorials</a></td></tr>'
-menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi.github.io/cmor-site/\');return document.MM_returnValue"><a href="http://pcmdi.github.io/cmor-site//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
+menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov/\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
 menuSoftware[7]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://cf-convention.github.io/\');return document.MM_returnValue"><a href="http://cf-convention.github.io" class="popupMenu" target="_blank">CF Conventions</a></td></tr>'
 menuSoftware[8]='</table>'
 

--- a/mips/amip/AMIP2EXPDSN/BCS/bcsintro.html
+++ b/mips/amip/AMIP2EXPDSN/BCS/bcsintro.html
@@ -101,14 +101,14 @@ menuSoftware[0]='<table width="100%" border="0" cellpadding="3" cellspacing="1" 
 //menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/download/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/download/" class="popupMenu">Downloads</a></td></tr>'
 //menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/support/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/support/" class="popupMenu">Support</a></td></tr>'
 //menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/" class="popupMenu">UV-CDAT</a></td></tr>'
-//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://pcmdi.github.io/cmor-site//\');return document.MM_returnValue"><a href="https://pcmdi.github.io/cmor-site//" class="popupMenu">CMOR</a></td></tr>'
+//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov//\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu">CMOR</a></td></tr>'
 
 menuSoftware[1]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://aims.llnl.gov/\');return document.MM_returnValue"><a href="http://aims.llnl.gov/" class="popupMenu" target="_blank">AIMS</a></td></tr>'
 menuSoftware[2]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://esgf.llnl.gov/\');return document.MM_returnValue"><a href="http://esgf.llnl.gov/" class="popupMenu" target="_blank">ESGF</a></td></tr>'
 menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi9.llnl.gov/esgf-web-fe/\');return document.MM_returnValue"><a href="http://pcmdi9.llnl.gov/esgf-web-fe/" class="popupMenu" target="_blank">ESGF Node</a></td></tr>'
 menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uvcdat.llnl.gov/\');return document.MM_returnValue"><a href="http://uvcdat.llnl.gov/" class="popupMenu" target="_blank">UV-CDAT</a></td></tr>'
 menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uv-cdat.github.io/cdat-site/\');return document.MM_returnValue"><a href="http://uv-cdat.github.io/cdat-site/" class="popupMenu" target="_blank">Old CDAT Tutorials</a></td></tr>'
-menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi.github.io/cmor-site/\');return document.MM_returnValue"><a href="http://pcmdi.github.io/cmor-site//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
+menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov/\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
 menuSoftware[7]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://cf-convention.github.io/\');return document.MM_returnValue"><a href="http://cf-convention.github.io" class="popupMenu" target="_blank">CF Conventions</a></td></tr>'
 menuSoftware[8]='</table>'
 

--- a/mips/amip/AMIP2EXPDSN/BCS/index.html
+++ b/mips/amip/AMIP2EXPDSN/BCS/index.html
@@ -101,14 +101,14 @@ menuSoftware[0]='<table width="100%" border="0" cellpadding="3" cellspacing="1" 
 //menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/download/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/download/" class="popupMenu">Downloads</a></td></tr>'
 //menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/support/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/support/" class="popupMenu">Support</a></td></tr>'
 //menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/" class="popupMenu">UV-CDAT</a></td></tr>'
-//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://pcmdi.github.io/cmor-site//\');return document.MM_returnValue"><a href="https://pcmdi.github.io/cmor-site//" class="popupMenu">CMOR</a></td></tr>'
+//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov//\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu">CMOR</a></td></tr>'
 
 menuSoftware[1]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://aims.llnl.gov/\');return document.MM_returnValue"><a href="http://aims.llnl.gov/" class="popupMenu" target="_blank">AIMS</a></td></tr>'
 menuSoftware[2]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://esgf.llnl.gov/\');return document.MM_returnValue"><a href="http://esgf.llnl.gov/" class="popupMenu" target="_blank">ESGF</a></td></tr>'
 menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi9.llnl.gov/esgf-web-fe/\');return document.MM_returnValue"><a href="http://pcmdi9.llnl.gov/esgf-web-fe/" class="popupMenu" target="_blank">ESGF Node</a></td></tr>'
 menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uvcdat.llnl.gov/\');return document.MM_returnValue"><a href="http://uvcdat.llnl.gov/" class="popupMenu" target="_blank">UV-CDAT</a></td></tr>'
 menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uv-cdat.github.io/cdat-site/\');return document.MM_returnValue"><a href="http://uv-cdat.github.io/cdat-site/" class="popupMenu" target="_blank">Old CDAT Tutorials</a></td></tr>'
-menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi.github.io/cmor-site/\');return document.MM_returnValue"><a href="http://pcmdi.github.io/cmor-site//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
+menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov/\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
 menuSoftware[7]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://cf-convention.github.io/\');return document.MM_returnValue"><a href="http://cf-convention.github.io" class="popupMenu" target="_blank">CF Conventions</a></td></tr>'
 menuSoftware[8]='</table>'
 

--- a/mips/amip/AMIP2EXPDSN/reqrec.html
+++ b/mips/amip/AMIP2EXPDSN/reqrec.html
@@ -101,14 +101,14 @@ menuSoftware[0]='<table width="100%" border="0" cellpadding="3" cellspacing="1" 
 //menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/download/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/download/" class="popupMenu">Downloads</a></td></tr>'
 //menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/support/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/support/" class="popupMenu">Support</a></td></tr>'
 //menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/" class="popupMenu">UV-CDAT</a></td></tr>'
-//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://pcmdi.github.io/cmor-site//\');return document.MM_returnValue"><a href="https://pcmdi.github.io/cmor-site//" class="popupMenu">CMOR</a></td></tr>'
+//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov//\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu">CMOR</a></td></tr>'
 
 menuSoftware[1]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://aims.llnl.gov/\');return document.MM_returnValue"><a href="http://aims.llnl.gov/" class="popupMenu" target="_blank">AIMS</a></td></tr>'
 menuSoftware[2]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://esgf.llnl.gov/\');return document.MM_returnValue"><a href="http://esgf.llnl.gov/" class="popupMenu" target="_blank">ESGF</a></td></tr>'
 menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi9.llnl.gov/esgf-web-fe/\');return document.MM_returnValue"><a href="http://pcmdi9.llnl.gov/esgf-web-fe/" class="popupMenu" target="_blank">ESGF Node</a></td></tr>'
 menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uvcdat.llnl.gov/\');return document.MM_returnValue"><a href="http://uvcdat.llnl.gov/" class="popupMenu" target="_blank">UV-CDAT</a></td></tr>'
 menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uv-cdat.github.io/cdat-site/\');return document.MM_returnValue"><a href="http://uv-cdat.github.io/cdat-site/" class="popupMenu" target="_blank">Old CDAT Tutorials</a></td></tr>'
-menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi.github.io/cmor-site/\');return document.MM_returnValue"><a href="http://pcmdi.github.io/cmor-site//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
+menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov/\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
 menuSoftware[7]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://cf-convention.github.io/\');return document.MM_returnValue"><a href="http://cf-convention.github.io" class="popupMenu" target="_blank">CF Conventions</a></td></tr>'
 menuSoftware[8]='</table>'
 

--- a/mips/amip/DATASTDS/datastds.html
+++ b/mips/amip/DATASTDS/datastds.html
@@ -101,14 +101,14 @@ menuSoftware[0]='<table width="100%" border="0" cellpadding="3" cellspacing="1" 
 //menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/download/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/download/" class="popupMenu">Downloads</a></td></tr>'
 //menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/support/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/support/" class="popupMenu">Support</a></td></tr>'
 //menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/" class="popupMenu">UV-CDAT</a></td></tr>'
-//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://pcmdi.github.io/cmor-site//\');return document.MM_returnValue"><a href="https://pcmdi.github.io/cmor-site//" class="popupMenu">CMOR</a></td></tr>'
+//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov//\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu">CMOR</a></td></tr>'
 
 menuSoftware[1]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://aims.llnl.gov/\');return document.MM_returnValue"><a href="http://aims.llnl.gov/" class="popupMenu" target="_blank">AIMS</a></td></tr>'
 menuSoftware[2]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://esgf.llnl.gov/\');return document.MM_returnValue"><a href="http://esgf.llnl.gov/" class="popupMenu" target="_blank">ESGF</a></td></tr>'
 menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi9.llnl.gov/esgf-web-fe/\');return document.MM_returnValue"><a href="http://pcmdi9.llnl.gov/esgf-web-fe/" class="popupMenu" target="_blank">ESGF Node</a></td></tr>'
 menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uvcdat.llnl.gov/\');return document.MM_returnValue"><a href="http://uvcdat.llnl.gov/" class="popupMenu" target="_blank">UV-CDAT</a></td></tr>'
 menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uv-cdat.github.io/cdat-site/\');return document.MM_returnValue"><a href="http://uv-cdat.github.io/cdat-site/" class="popupMenu" target="_blank">Old CDAT Tutorials</a></td></tr>'
-menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi.github.io/cmor-site/\');return document.MM_returnValue"><a href="http://pcmdi.github.io/cmor-site//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
+menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov/\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
 menuSoftware[7]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://cf-convention.github.io/\');return document.MM_returnValue"><a href="http://cf-convention.github.io" class="popupMenu" target="_blank">CF Conventions</a></td></tr>'
 menuSoftware[8]='</table>'
 

--- a/mips/amip/NEWS/AMIPconference.html
+++ b/mips/amip/NEWS/AMIPconference.html
@@ -101,14 +101,14 @@ menuSoftware[0]='<table width="100%" border="0" cellpadding="3" cellspacing="1" 
 //menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/download/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/download/" class="popupMenu">Downloads</a></td></tr>'
 //menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/support/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/support/" class="popupMenu">Support</a></td></tr>'
 //menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/" class="popupMenu">UV-CDAT</a></td></tr>'
-//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://pcmdi.github.io/cmor-site//\');return document.MM_returnValue"><a href="https://pcmdi.github.io/cmor-site//" class="popupMenu">CMOR</a></td></tr>'
+//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov//\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu">CMOR</a></td></tr>'
 
 menuSoftware[1]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://aims.llnl.gov/\');return document.MM_returnValue"><a href="http://aims.llnl.gov/" class="popupMenu" target="_blank">AIMS</a></td></tr>'
 menuSoftware[2]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://esgf.llnl.gov/\');return document.MM_returnValue"><a href="http://esgf.llnl.gov/" class="popupMenu" target="_blank">ESGF</a></td></tr>'
 menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi9.llnl.gov/esgf-web-fe/\');return document.MM_returnValue"><a href="http://pcmdi9.llnl.gov/esgf-web-fe/" class="popupMenu" target="_blank">ESGF Node</a></td></tr>'
 menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uvcdat.llnl.gov/\');return document.MM_returnValue"><a href="http://uvcdat.llnl.gov/" class="popupMenu" target="_blank">UV-CDAT</a></td></tr>'
 menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uv-cdat.github.io/cdat-site/\');return document.MM_returnValue"><a href="http://uv-cdat.github.io/cdat-site/" class="popupMenu" target="_blank">Old CDAT Tutorials</a></td></tr>'
-menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi.github.io/cmor-site/\');return document.MM_returnValue"><a href="http://pcmdi.github.io/cmor-site//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
+menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov/\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
 menuSoftware[7]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://cf-convention.github.io/\');return document.MM_returnValue"><a href="http://cf-convention.github.io" class="popupMenu" target="_blank">CF Conventions</a></td></tr>'
 menuSoftware[8]='</table>'
 

--- a/mips/amip/NEWS/amipnl7.html
+++ b/mips/amip/NEWS/amipnl7.html
@@ -101,14 +101,14 @@ menuSoftware[0]='<table width="100%" border="0" cellpadding="3" cellspacing="1" 
 //menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/download/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/download/" class="popupMenu">Downloads</a></td></tr>'
 //menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/support/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/support/" class="popupMenu">Support</a></td></tr>'
 //menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/" class="popupMenu">UV-CDAT</a></td></tr>'
-//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://pcmdi.github.io/cmor-site//\');return document.MM_returnValue"><a href="https://pcmdi.github.io/cmor-site//" class="popupMenu">CMOR</a></td></tr>'
+//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov//\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu">CMOR</a></td></tr>'
 
 menuSoftware[1]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://aims.llnl.gov/\');return document.MM_returnValue"><a href="http://aims.llnl.gov/" class="popupMenu" target="_blank">AIMS</a></td></tr>'
 menuSoftware[2]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://esgf.llnl.gov/\');return document.MM_returnValue"><a href="http://esgf.llnl.gov/" class="popupMenu" target="_blank">ESGF</a></td></tr>'
 menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi9.llnl.gov/esgf-web-fe/\');return document.MM_returnValue"><a href="http://pcmdi9.llnl.gov/esgf-web-fe/" class="popupMenu" target="_blank">ESGF Node</a></td></tr>'
 menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uvcdat.llnl.gov/\');return document.MM_returnValue"><a href="http://uvcdat.llnl.gov/" class="popupMenu" target="_blank">UV-CDAT</a></td></tr>'
 menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uv-cdat.github.io/cdat-site/\');return document.MM_returnValue"><a href="http://uv-cdat.github.io/cdat-site/" class="popupMenu" target="_blank">Old CDAT Tutorials</a></td></tr>'
-menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi.github.io/cmor-site/\');return document.MM_returnValue"><a href="http://pcmdi.github.io/cmor-site//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
+menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov/\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
 menuSoftware[7]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://cf-convention.github.io/\');return document.MM_returnValue"><a href="http://cf-convention.github.io" class="popupMenu" target="_blank">CF Conventions</a></td></tr>'
 menuSoftware[8]='</table>'
 

--- a/mips/amip/NEWS/amipnl8.html
+++ b/mips/amip/NEWS/amipnl8.html
@@ -101,14 +101,14 @@ menuSoftware[0]='<table width="100%" border="0" cellpadding="3" cellspacing="1" 
 //menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/download/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/download/" class="popupMenu">Downloads</a></td></tr>'
 //menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/support/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/support/" class="popupMenu">Support</a></td></tr>'
 //menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/" class="popupMenu">UV-CDAT</a></td></tr>'
-//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://pcmdi.github.io/cmor-site//\');return document.MM_returnValue"><a href="https://pcmdi.github.io/cmor-site//" class="popupMenu">CMOR</a></td></tr>'
+//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov//\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu">CMOR</a></td></tr>'
 
 menuSoftware[1]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://aims.llnl.gov/\');return document.MM_returnValue"><a href="http://aims.llnl.gov/" class="popupMenu" target="_blank">AIMS</a></td></tr>'
 menuSoftware[2]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://esgf.llnl.gov/\');return document.MM_returnValue"><a href="http://esgf.llnl.gov/" class="popupMenu" target="_blank">ESGF</a></td></tr>'
 menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi9.llnl.gov/esgf-web-fe/\');return document.MM_returnValue"><a href="http://pcmdi9.llnl.gov/esgf-web-fe/" class="popupMenu" target="_blank">ESGF Node</a></td></tr>'
 menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uvcdat.llnl.gov/\');return document.MM_returnValue"><a href="http://uvcdat.llnl.gov/" class="popupMenu" target="_blank">UV-CDAT</a></td></tr>'
 menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uv-cdat.github.io/cdat-site/\');return document.MM_returnValue"><a href="http://uv-cdat.github.io/cdat-site/" class="popupMenu" target="_blank">Old CDAT Tutorials</a></td></tr>'
-menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi.github.io/cmor-site/\');return document.MM_returnValue"><a href="http://pcmdi.github.io/cmor-site//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
+menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov/\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
 menuSoftware[7]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://cf-convention.github.io/\');return document.MM_returnValue"><a href="http://cf-convention.github.io" class="popupMenu" target="_blank">CF Conventions</a></td></tr>'
 menuSoftware[8]='</table>'
 

--- a/mips/amip/NEWS/overview.html
+++ b/mips/amip/NEWS/overview.html
@@ -101,14 +101,14 @@ menuSoftware[0]='<table width="100%" border="0" cellpadding="3" cellspacing="1" 
 //menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/download/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/download/" class="popupMenu">Downloads</a></td></tr>'
 //menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/support/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/support/" class="popupMenu">Support</a></td></tr>'
 //menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/" class="popupMenu">UV-CDAT</a></td></tr>'
-//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://pcmdi.github.io/cmor-site//\');return document.MM_returnValue"><a href="https://pcmdi.github.io/cmor-site//" class="popupMenu">CMOR</a></td></tr>'
+//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov//\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu">CMOR</a></td></tr>'
 
 menuSoftware[1]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://aims.llnl.gov/\');return document.MM_returnValue"><a href="http://aims.llnl.gov/" class="popupMenu" target="_blank">AIMS</a></td></tr>'
 menuSoftware[2]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://esgf.llnl.gov/\');return document.MM_returnValue"><a href="http://esgf.llnl.gov/" class="popupMenu" target="_blank">ESGF</a></td></tr>'
 menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi9.llnl.gov/esgf-web-fe/\');return document.MM_returnValue"><a href="http://pcmdi9.llnl.gov/esgf-web-fe/" class="popupMenu" target="_blank">ESGF Node</a></td></tr>'
 menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uvcdat.llnl.gov/\');return document.MM_returnValue"><a href="http://uvcdat.llnl.gov/" class="popupMenu" target="_blank">UV-CDAT</a></td></tr>'
 menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uv-cdat.github.io/cdat-site/\');return document.MM_returnValue"><a href="http://uv-cdat.github.io/cdat-site/" class="popupMenu" target="_blank">Old CDAT Tutorials</a></td></tr>'
-menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi.github.io/cmor-site/\');return document.MM_returnValue"><a href="http://pcmdi.github.io/cmor-site//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
+menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov/\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
 menuSoftware[7]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://cf-convention.github.io/\');return document.MM_returnValue"><a href="http://cf-convention.github.io" class="popupMenu" target="_blank">CF Conventions</a></td></tr>'
 menuSoftware[8]='</table>'
 

--- a/mips/amip/amip2_workshop_proceedings.html
+++ b/mips/amip/amip2_workshop_proceedings.html
@@ -101,14 +101,14 @@ menuSoftware[0]='<table width="100%" border="0" cellpadding="3" cellspacing="1" 
 //menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/download/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/download/" class="popupMenu">Downloads</a></td></tr>'
 //menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/support/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/support/" class="popupMenu">Support</a></td></tr>'
 //menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/" class="popupMenu">UV-CDAT</a></td></tr>'
-//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://pcmdi.github.io/cmor-site//\');return document.MM_returnValue"><a href="https://pcmdi.github.io/cmor-site//" class="popupMenu">CMOR</a></td></tr>'
+//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov//\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu">CMOR</a></td></tr>'
 
 menuSoftware[1]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://aims.llnl.gov/\');return document.MM_returnValue"><a href="http://aims.llnl.gov/" class="popupMenu" target="_blank">AIMS</a></td></tr>'
 menuSoftware[2]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://esgf.llnl.gov/\');return document.MM_returnValue"><a href="http://esgf.llnl.gov/" class="popupMenu" target="_blank">ESGF</a></td></tr>'
 menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi9.llnl.gov/esgf-web-fe/\');return document.MM_returnValue"><a href="http://pcmdi9.llnl.gov/esgf-web-fe/" class="popupMenu" target="_blank">ESGF Node</a></td></tr>'
 menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uvcdat.llnl.gov/\');return document.MM_returnValue"><a href="http://uvcdat.llnl.gov/" class="popupMenu" target="_blank">UV-CDAT</a></td></tr>'
 menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uv-cdat.github.io/cdat-site/\');return document.MM_returnValue"><a href="http://uv-cdat.github.io/cdat-site/" class="popupMenu" target="_blank">Old CDAT Tutorials</a></td></tr>'
-menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi.github.io/cmor-site/\');return document.MM_returnValue"><a href="http://pcmdi.github.io/cmor-site//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
+menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov/\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
 menuSoftware[7]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://cf-convention.github.io/\');return document.MM_returnValue"><a href="http://cf-convention.github.io" class="popupMenu" target="_blank">CF Conventions</a></td></tr>'
 menuSoftware[8]='</table>'
 

--- a/mips/amip/home/news/amipnl8.html
+++ b/mips/amip/home/news/amipnl8.html
@@ -101,14 +101,14 @@ menuSoftware[0]='<table width="100%" border="0" cellpadding="3" cellspacing="1" 
 //menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/download/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/download/" class="popupMenu">Downloads</a></td></tr>'
 //menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/support/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/support/" class="popupMenu">Support</a></td></tr>'
 //menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/" class="popupMenu">UV-CDAT</a></td></tr>'
-//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://pcmdi.github.io/cmor-site//\');return document.MM_returnValue"><a href="https://pcmdi.github.io/cmor-site//" class="popupMenu">CMOR</a></td></tr>'
+//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov//\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu">CMOR</a></td></tr>'
 
 menuSoftware[1]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://aims.llnl.gov/\');return document.MM_returnValue"><a href="http://aims.llnl.gov/" class="popupMenu" target="_blank">AIMS</a></td></tr>'
 menuSoftware[2]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://esgf.llnl.gov/\');return document.MM_returnValue"><a href="http://esgf.llnl.gov/" class="popupMenu" target="_blank">ESGF</a></td></tr>'
 menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi9.llnl.gov/esgf-web-fe/\');return document.MM_returnValue"><a href="http://pcmdi9.llnl.gov/esgf-web-fe/" class="popupMenu" target="_blank">ESGF Node</a></td></tr>'
 menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uvcdat.llnl.gov/\');return document.MM_returnValue"><a href="http://uvcdat.llnl.gov/" class="popupMenu" target="_blank">UV-CDAT</a></td></tr>'
 menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uv-cdat.github.io/cdat-site/\');return document.MM_returnValue"><a href="http://uv-cdat.github.io/cdat-site/" class="popupMenu" target="_blank">Old CDAT Tutorials</a></td></tr>'
-menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi.github.io/cmor-site/\');return document.MM_returnValue"><a href="http://pcmdi.github.io/cmor-site//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
+menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov/\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
 menuSoftware[7]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://cf-convention.github.io/\');return document.MM_returnValue"><a href="http://cf-convention.github.io" class="popupMenu" target="_blank">CF Conventions</a></td></tr>'
 menuSoftware[8]='</table>'
 

--- a/mips/amip/index-2.html
+++ b/mips/amip/index-2.html
@@ -101,14 +101,14 @@ menuSoftware[0]='<table width="100%" border="0" cellpadding="3" cellspacing="1" 
 //menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/download/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/download/" class="popupMenu">Downloads</a></td></tr>'
 //menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/support/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/support/" class="popupMenu">Support</a></td></tr>'
 //menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://www-pcmdi.llnl.gov/software-portal/cdat/\');return document.MM_returnValue"><a href="http://www-pcmdi.llnl.gov/software-portal/cdat/" class="popupMenu">UV-CDAT</a></td></tr>'
-//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://pcmdi.github.io/cmor-site//\');return document.MM_returnValue"><a href="https://pcmdi.github.io/cmor-site//" class="popupMenu">CMOR</a></td></tr>'
+//menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov//\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu">CMOR</a></td></tr>'
 
 menuSoftware[1]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://aims.llnl.gov/\');return document.MM_returnValue"><a href="http://aims.llnl.gov/" class="popupMenu" target="_blank">AIMS</a></td></tr>'
 menuSoftware[2]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://esgf.llnl.gov/\');return document.MM_returnValue"><a href="http://esgf.llnl.gov/" class="popupMenu" target="_blank">ESGF</a></td></tr>'
 menuSoftware[3]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi9.llnl.gov/esgf-web-fe/\');return document.MM_returnValue"><a href="http://pcmdi9.llnl.gov/esgf-web-fe/" class="popupMenu" target="_blank">ESGF Node</a></td></tr>'
 menuSoftware[4]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uvcdat.llnl.gov/\');return document.MM_returnValue"><a href="http://uvcdat.llnl.gov/" class="popupMenu" target="_blank">UV-CDAT</a></td></tr>'
 menuSoftware[5]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://uv-cdat.github.io/cdat-site/\');return document.MM_returnValue"><a href="http://uv-cdat.github.io/cdat-site/" class="popupMenu" target="_blank">Old CDAT Tutorials</a></td></tr>'
-menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://pcmdi.github.io/cmor-site/\');return document.MM_returnValue"><a href="http://pcmdi.github.io/cmor-site//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
+menuSoftware[6]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'https://cmor.llnl.gov/\');return document.MM_returnValue"><a href="https://cmor.llnl.gov//" class="popupMenu" target="_blank">CMOR</a></td></tr>'
 menuSoftware[7]='<tr><td class="popupMenu" onMouseDown="MM_goToURL(\'parent\',\'http://cf-convention.github.io/\');return document.MM_returnValue"><a href="http://cf-convention.github.io" class="popupMenu" target="_blank">CF Conventions</a></td></tr>'
 menuSoftware[8]='</table>'
 

--- a/mips/cmip2/standard_output.html
+++ b/mips/cmip2/standard_output.html
@@ -202,7 +202,7 @@ time step. </p>
 This code structures the data uniformly and writes netCDF files in full compliance
 with IPCC requirements. Use of CMOR is being encouraged (and in some cases
 required) by various ongoing model intercomparison projects.&nbsp; The CMOR
-documentation in pdf format is available <a href="../software/cmor/cmor_users_guide.pdf">here</a>,
+documentation in pdf format is available <a href="{{site.baseurl}}/software/cmor/cmor_users_guide.pdf">here</a>,
 and the source code is available at&nbsp; <a href="https://github.com/PCMDI/cmor">Github.com</a>.
 For further information, contact <a href="mailto:taylor13@llnl.gov">taylor13@llnl.gov.</a></p>
 

--- a/mips/cmip3/home.html
+++ b/mips/cmip3/home.html
@@ -100,7 +100,7 @@ historical details</a></p>
                                 <a href="../../ipcc/IPCC_output_requirements.htm">Model
                                 output requirements</a>.</li>
                                 <li>
-                                <a href="software/cmor/cmor_users_guide.pdf">CMOR software</a> for producing output
+                                <a href="https://cmor.llnl.gov">CMOR software</a> for producing output
                                 conforming to IPCC requirements is available
                                 <a href="https://github.com/PCMDI/cmor">here</a>.</li>
                                 </ul>

--- a/mips/cmip3/index.md
+++ b/mips/cmip3/index.md
@@ -58,7 +58,7 @@ As of January 2007, over 35 terabytes of data were in the archive and over 337 t
 * [Step-by-step procedure.](/ipcc/data_transfer_procedure.html)
 * [List of requested simulations and standard model output.](/ipcc/standard_output.html)
 * [Model output requirements.](/ipcc/IPCC_output_requirements.htm)
-* [CMOR software]({{site.baseurl}}software/cmor/cmor_users_guide.pdf) for producing output conforming to IPCC requirements is available here.
+* [CMOR software](https://cmor.llnl.gov/) for producing output conforming to IPCC requirements is available here.
 3. [Additional important requests and information](/ipcc/info_for_modeling_groups.html)
 
 ### Overview presentations concerning the WCRP CMIP3 multi-model dataset archived at PCMDI:

--- a/mips/cmip3/variableList.html
+++ b/mips/cmip3/variableList.html
@@ -202,12 +202,12 @@ typical model output history files, which contain all variables for a single
 time step. </p>
 
 <p>To facilitate adherence to these standards, the PCMDI has written (in FORTRAN
-90) a standard output code called CMOR (pronounced "see more"; see <a href="https://pcmdi.github.io/cmor-site/">https://pcmdi.github.io/cmor-site/</a>).
+90) a standard output code called CMOR (pronounced "see more"; see <a href="https://cmor.llnl.gov/archive/cmor1/">https://cmor.llnl.gov/archive/cmor1/</a>).
 This code structures the data uniformly and writes netCDF files in full compliance
 with IPCC requirements. Use of CMOR is being encouraged (and in some cases
 required) by various ongoing model intercomparison projects.&nbsp; The CMOR
-documentation in pdf format is available at <a href="{{site.baseurl}}/software/cmor/cmor_users_guide.pdf">cmor_users_guide.pdf</a>,
-and the source code is available at&nbsp; <a href="https://pcmdi.github.io/cmor-site/">https://pcmdi.github.io/cmor-site/</a>.
+documentation in pdf format is available at <a href="https://cmor.llnl.gov/archive/cmor1/cmor_users_guide.pdf">cmor_users_guide.pdf</a>,
+and the source code is available at&nbsp; <a href="https://cmor.llnl.gov/archive/cmor1/">https://cmor.llnl.gov/archive/cmor1/</a>.
 For further information, contact <a href="mailto:taylor13@llnl.gov">taylor13@llnl.gov.</a></p>
 
 <p>The notes that appear in the following tables are meant to provide precise


### PR DESCRIPTION
This PR changes links for the CMOR documentation that originally pointed to a GitHub Pages site to links to cmor.llnl.gov.  This includes links to a [CMOR 1 archive page](https://cmor.llnl.gov/archive/cmor1/) for some links that refer to the original Fortran-based CMOR.

This PR also fixes some links to the CMOR 1 doc PDF.