### PR TITLE
Update Mean Climate Portrait Plot

### DIFF
--- a/research/metrics/v1.6.2/mean_clim/index.md
+++ b/research/metrics/v1.6.2/mean_clim/index.md
@@ -57,10 +57,10 @@ Gleckler, P. J., K. E. Taylor, and C. Doutriaux, 2008: Performance metrics for m
 
 Taylor, K. E., 2001: Summarizing multiple aspects of model performance in a single diagram. J. Geophys. Res., 106, 7183–7192, [doi: 10.1029/2000JD900719][taylor2001].
 
-[portrait_cmip6_hist]: https://pcmdi.llnl.gov/pmp-preliminary-results/interactive_plot/portrait_plot/mean_clim/cmip6/historical/v20220919/mean_clim_portrait_plot_4seasons_cmip6_historical_rms_xy_v20220919.html 
-[portrait_cmip5_hist]: https://pcmdi.llnl.gov/pmp-preliminary-results/interactive_plot/portrait_plot/mean_clim/cmip6/historical/v20220919/mean_clim_portrait_plot_4seasons_cmip5_historical_rms_xy_v20220919.html
-[portrait_cmip6_amip]: https://pcmdi.llnl.gov/pmp-preliminary-results/interactive_plot/portrait_plot/mean_clim/cmip6/historical/v20220919/mean_clim_portrait_plot_4seasons_cmip6_amip_rms_xy_v20220919.html
-[portrait_cmip5_amip]: https://pcmdi.llnl.gov/pmp-preliminary-results/interactive_plot/portrait_plot/mean_clim/cmip6/historical/v20220919/mean_clim_portrait_plot_4seasons_cmip5_amip_rms_xy_v20220919.html
+[portrait_cmip6_hist]: https://pcmdi.llnl.gov/pmp-preliminary-results/interactive_plot/portrait_plot/mean_clim/cmip6/historical/v20240430/mean_clim_portrait_plot_4seasons_cmip6_historical_rms_xy_v20240430.html 
+[portrait_cmip5_hist]: https://pcmdi.llnl.gov/pmp-preliminary-results/interactive_plot/portrait_plot/mean_clim/cmip6/historical/v20240430/mean_clim_portrait_plot_4seasons_cmip5_historical_rms_xy_v20240430.html
+[portrait_cmip6_amip]: https://pcmdi.llnl.gov/pmp-preliminary-results/interactive_plot/portrait_plot/mean_clim/cmip6/historical/v20240430/mean_clim_portrait_plot_4seasons_cmip6_amip_rms_xy_v20240430.html
+[portrait_cmip5_amip]: https://pcmdi.llnl.gov/pmp-preliminary-results/interactive_plot/portrait_plot/mean_clim/cmip6/historical/v20240430/mean_clim_portrait_plot_4seasons_cmip5_amip_rms_xy_v20240430.html
 
 [portrait_cmip6_hist_old]: https://pcmdi.llnl.gov/pmp-preliminary-results/interactive_plot/portrait_plot/mean_clim/cmip6/historical/v20201008/global/rms_xy_season/clickable_portrait.html
 [portrait_cmip5_hist_old]: https://pcmdi.llnl.gov/pmp-preliminary-results/interactive_plot/portrait_plot/mean_clim/cmip5/historical/v20200506/clickable_portrait.html


### PR DESCRIPTION
Hi @lee1043,

I uploaded most recent version of the mean climate portrait plot to the PCMDI web server (v20240430). This includes two new features: 1) a "No Data Available here" default image for glyphs with NaN values and 2) the selection automatically clears after clicking on a glyph's image and returning to the portrait plot page.

This is related to this PR (https://github.com/PCMDI/PCMDI_Simulation_Summaries/pull/52 .