### PR TITLE
Add meta page description for each page

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,6 +3,7 @@
 <meta http-equiv="Content-type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="author" content="{{ site.author }}">
+<meta name="description" content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 
 <title>{{ page.title }}</title>
 


### PR DESCRIPTION
This will add a meta description tag to all pages.  To add a description to the page, add `description: ...` to the header of the page.
```
---
layout: default
title: Home
group: "navigation"
description: PCMDI website homepage
---
```

The meta descriptions for all of the pages will be blank until we start filling them in.